### PR TITLE
Add `--pixel-size` argument to override auto-detected size

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,18 @@ Build the WASM module:
 wasm-pack build --target web --out-dir pkg --release
 ```
 
-Then use the WASM module in your project.
+Then use the WASM module in your project:
+
+```js
+import init, { process_image } from "./pkg/spritefusion_pixel_snapper.js";
+
+await init();
+
+// process_image(inputBytes, kColors?, pixelSizeOverride?)
+const outputBytes = process_image(inputBytes, 16);
+```
+
+Pass `null` for any optional argument you want to leave on its default behavior.
 
 ## Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ The command accepts an optional k-colors argument:
 cargo run input.png output.png 16
 ```
 
+You can also override the auto-detected pixel size with `--pixel-size`:
+
+```bash
+cargo run input.png output.png --pixel-size 8
+```
+
+This is useful when the auto-detection doesn't match the expected grid size. The value must be between 1 and half the smallest image dimension.
+
 ### 🌐 Web (WASM)
 
 ```bash

--- a/src/main.rs
+++ b/src/main.rs
@@ -33,6 +33,7 @@ pub struct Config {
     min_cuts_per_axis: usize,
     fallback_target_segments: usize,
     max_step_ratio: f64,
+    pub pixel_size_override: Option<f64>,
 }
 
 impl Default for Config {
@@ -51,6 +52,7 @@ impl Default for Config {
             min_cuts_per_axis: 4,
             fallback_target_segments: 64,
             max_step_ratio: 1.8, // Lowered from 3.0 to catch more skew cases
+            pixel_size_override: None,
         }
     }
 }
@@ -105,6 +107,15 @@ fn process_image_bytes_common(input_bytes: &[u8], config: Option<Config>) -> Res
 
     validate_image_dimensions(width, height)?;
 
+    if let Some(px) = config.pixel_size_override {
+        if px < 1.0 || px > (width.min(height) as f64 / 2.0) {
+            return Err(PixelSnapperError::InvalidInput(format!(
+                "pixel_size_override {:.1} is out of valid range [1, {}]",
+                px, width.min(height) / 2
+            )));
+        }
+    }
+
     let rgba_img = img.to_rgba8();
 
     let quantized_img = quantize_image(&rgba_img, &config)?;
@@ -116,6 +127,9 @@ fn process_image_bytes_common(input_bytes: &[u8], config: Option<Config>) -> Res
 
     // Resolve step sizes. Some instabilities so use sibling axis if one fails, or fallback if both fail
     let (step_x, step_y) = resolve_step_sizes(step_x_opt, step_y_opt, width, height, &config);
+
+    println!("Pixel size: {:.1}px ({})", step_x,
+        if config.pixel_size_override.is_some() { "override" } else { "auto-detected" });
 
     let raw_col_cuts = walk(&profile_x, step_x, width as usize, &config)?;
     let raw_row_cuts = walk(&profile_y, step_y, height as usize, &config)?;
@@ -130,6 +144,8 @@ fn process_image_bytes_common(input_bytes: &[u8], config: Option<Config>) -> Res
         height as usize,
         &config,
     );
+
+    println!("Output size: {}x{}", col_cuts.len() - 1, row_cuts.len() - 1);
 
     let output_img = resample(&quantized_img, &col_cuts, &row_cuts)?;
 
@@ -179,12 +195,32 @@ fn parse_args() -> Option<Config> {
     };
 
     if let Some(k_arg) = args.get(3) {
-        match k_arg.parse::<usize>() {
-            Ok(k) if k > 0 => config.k_colors = k,
-            _ => eprintln!(
-                "Warning: invalid k_colors '{}', falling back to default ({})",
-                k_arg, config.k_colors
-            ),
+        if !k_arg.starts_with("--") {
+            match k_arg.parse::<usize>() {
+                Ok(k) if k > 0 => config.k_colors = k,
+                _ => eprintln!(
+                    "Warning: invalid k_colors '{}', falling back to default ({})",
+                    k_arg, config.k_colors
+                ),
+            }
+        }
+    }
+
+    let mut i = 3;
+    while i < args.len() {
+        if args[i] == "--pixel-size" {
+            if let Some(val) = args.get(i + 1) {
+                match val.parse::<f64>() {
+                    Ok(px) if px > 0.0 => config.pixel_size_override = Some(px),
+                    _ => eprintln!("Warning: invalid --pixel-size '{}', ignoring", val),
+                }
+                i += 2;
+            } else {
+                eprintln!("Warning: --pixel-size requires a value");
+                i += 1;
+            }
+        } else {
+            i += 1;
         }
     }
 
@@ -457,6 +493,10 @@ fn resolve_step_sizes(
     height: u32,
     config: &Config,
 ) -> (f64, f64) {
+    if let Some(px) = config.pixel_size_override {
+        return (px, px);
+    }
+
     match (step_x_opt, step_y_opt) {
         (Some(sx), Some(sy)) => {
             let ratio = if sx > sy { sx / sy } else { sy / sx };

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use wasm_bindgen::prelude::*;
 #[cfg_attr(target_arch = "wasm32", wasm_bindgen)]
 pub struct Config {
     pub k_colors: usize,
+    pub pixel_size_override: Option<f64>,
     k_seed: u64,
     /// Input image path only used for CLI use
     #[allow(dead_code)]
@@ -33,7 +34,6 @@ pub struct Config {
     min_cuts_per_axis: usize,
     fallback_target_segments: usize,
     max_step_ratio: f64,
-    pub pixel_size_override: Option<f64>,
 }
 
 impl Default for Config {
@@ -108,10 +108,11 @@ fn process_image_bytes_common(input_bytes: &[u8], config: Option<Config>) -> Res
     validate_image_dimensions(width, height)?;
 
     if let Some(px) = config.pixel_size_override {
-        if px < 1.0 || px > (width.min(height) as f64 / 2.0) {
+        if !px.is_finite() || px < 1.0 || px > (width.min(height) as f64 / 2.0) {
             return Err(PixelSnapperError::InvalidInput(format!(
                 "pixel_size_override {:.1} is out of valid range [1, {}]",
-                px, width.min(height) / 2
+                px,
+                width.min(height) / 2
             )));
         }
     }
@@ -128,8 +129,15 @@ fn process_image_bytes_common(input_bytes: &[u8], config: Option<Config>) -> Res
     // Resolve step sizes. Some instabilities so use sibling axis if one fails, or fallback if both fail
     let (step_x, step_y) = resolve_step_sizes(step_x_opt, step_y_opt, width, height, &config);
 
-    println!("Pixel size: {:.1}px ({})", step_x,
-        if config.pixel_size_override.is_some() { "override" } else { "auto-detected" });
+    println!(
+        "Pixel size: {:.1}px ({})",
+        step_x,
+        if config.pixel_size_override.is_some() {
+            "override"
+        } else {
+            "auto-detected"
+        }
+    );
 
     let raw_col_cuts = walk(&profile_x, step_x, width as usize, &config)?;
     let raw_row_cuts = walk(&profile_y, step_y, height as usize, &config)?;
@@ -165,6 +173,7 @@ fn process_image_bytes_common(input_bytes: &[u8], config: Option<Config>) -> Res
 pub fn process_image(
     input_bytes: &[u8],
     k_colors: Option<u32>,
+    pixel_size_override: Option<f64>,
 ) -> std::result::Result<Vec<u8>, wasm_bindgen::JsValue> {
     let mut config = Config::default();
     if let Some(k) = k_colors {
@@ -175,6 +184,8 @@ pub fn process_image(
         }
         config.k_colors = k as usize;
     }
+    
+    config.pixel_size_override = pixel_size_override;
 
     process_image_bytes_common(input_bytes, Some(config))
         .map_err(|e| wasm_bindgen::JsValue::from(e))

--- a/src/main.rs
+++ b/src/main.rs
@@ -184,7 +184,7 @@ pub fn process_image(
         }
         config.k_colors = k as usize;
     }
-    
+
     config.pixel_size_override = pixel_size_override;
 
     process_image_bytes_common(input_bytes, Some(config))
@@ -205,33 +205,35 @@ fn parse_args() -> Option<Config> {
         ..Default::default()
     };
 
-    if let Some(k_arg) = args.get(3) {
-        if !k_arg.starts_with("--") {
-            match k_arg.parse::<usize>() {
-                Ok(k) if k > 0 => config.k_colors = k,
-                _ => eprintln!(
-                    "Warning: invalid k_colors '{}', falling back to default ({})",
-                    k_arg, config.k_colors
-                ),
-            }
-        }
-    }
-
     let mut i = 3;
     while i < args.len() {
-        if args[i] == "--pixel-size" {
-            if let Some(val) = args.get(i + 1) {
+        match args[i].as_str() {
+            "--pixel-size" => {
+                let Some(val) = args.get(i + 1) else {
+                    eprintln!("Warning: --pixel-size requires a value");
+                    break;
+                };
+
                 match val.parse::<f64>() {
-                    Ok(px) if px > 0.0 => config.pixel_size_override = Some(px),
+                    Ok(px) if px.is_finite() && px > 0.0 => config.pixel_size_override = Some(px),
                     _ => eprintln!("Warning: invalid --pixel-size '{}', ignoring", val),
                 }
                 i += 2;
-            } else {
-                eprintln!("Warning: --pixel-size requires a value");
+            }
+            arg if arg.starts_with("--") => {
+                eprintln!("Warning: unknown argument '{}', ignoring", arg);
                 i += 1;
             }
-        } else {
-            i += 1;
+            k_arg => {
+                match k_arg.parse::<usize>() {
+                    Ok(k) if k > 0 => config.k_colors = k,
+                    _ => eprintln!(
+                        "Warning: invalid k_colors '{}', falling back to default ({})",
+                        k_arg, config.k_colors
+                    ),
+                }
+                i += 1;
+            }
         }
     }
 


### PR DESCRIPTION
Very cool project!

However, I’ve found it often fails to detect a good pixel resolution, resulting in messy pixel art.
This attribute aims to add a bit of control to the tool.